### PR TITLE
Avoid relying on provider context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ docs/_build/
 # QuickBuild
 .qbcache/
 .cloudify
+
+.idea/
+

--- a/inputs/openstack.yaml
+++ b/inputs/openstack.yaml
@@ -1,3 +1,13 @@
-image_id: '' # The UUID of an Openstack Ubuntu 14.04 Image.
-flavor_id: '' # The UUID of an Openstack Flavor
+keystone_username: ''
+keystone_password: ''
+keystone_tenant_name: ''
+keystone_url: ''
+region: ''
+image_id: ''
+flavor_id: ''
 agent_user: ubuntu
+agents_security_group: ''
+network_name: ''
+floating_network_name: ''
+key_pair_name: ''
+private_key_path: ''

--- a/openstack-haproxy-blueprint.yaml
+++ b/openstack-haproxy-blueprint.yaml
@@ -315,8 +315,6 @@ node_templates:
           port: { get_property: [ mongod, port ] }
         - remote_ip_prefix: 0.0.0.0/0
           port: 28017
-        - remote_ip_prefix: 0.0.0.0/0
-          port: 22
 
   ###########################################################
   # A security group to enable access to the nodejs host
@@ -334,8 +332,6 @@ node_templates:
       rules:
         - remote_ip_prefix: 0.0.0.0/0
           port: { get_property: [ nodecellar, port ] }
-        - remote_ip_prefix: 0.0.0.0/0
-          port: 22
 
   ###########################################################
   # A security group to enable access to the haproxy frontend
@@ -357,8 +353,6 @@ node_templates:
           port: { get_property: [ haproxy, frontend_port ] }
         - remote_ip_prefix: 0.0.0.0/0
           port: { get_property: [ haproxy, statistics_port ]}
-        - remote_ip_prefix: 0.0.0.0/0
-          port: 22
 
   ###########################################################
   # An ip to be attached to the haproxy frontend host, since

--- a/openstack-haproxy-blueprint.yaml
+++ b/openstack-haproxy-blueprint.yaml
@@ -5,8 +5,8 @@ description: >
   an haproxy instance on an openstack cloud environment.
 
 imports:
-  - http://www.getcloudify.org/spec/cloudify/3.4/types.yaml
-  - http://www.getcloudify.org/spec/openstack-plugin/1.5/plugin.yaml
+  - http://www.getcloudify.org/spec/cloudify/3.4.1/types.yaml
+  - http://www.getcloudify.org/spec/openstack-plugin/2.0/plugin.yaml
   - http://www.getcloudify.org/spec/diamond-plugin/1.3.3/plugin.yaml
   - types/nodecellar.yaml
   - types/openstack-types.yaml
@@ -23,6 +23,36 @@ imports:
 
 inputs:
 
+  keystone_username:
+    description: >
+      Username to use when authenticating to KeyStone.
+    default: ''
+    type: string
+
+  keystone_password:
+    description: >
+      Password to use when authenticating to KeyStone.
+    default: ''
+    type: string
+
+  keystone_tenant_name:
+    description: >
+      Name of tenant to create resources on.
+    default: ''
+    type: string
+
+  keystone_url:
+    description: >
+      URL of OpenStack's KeyStone API endpoint.
+    default: ''
+    type: string
+
+  region:
+    description: >
+      Region to create resources in.
+    default: ''
+    type: string
+
   image_id:
     description: >
       An Openstack Image ID. Tested with a Ubuntu 14.04 image.
@@ -34,6 +64,37 @@ inputs:
   agent_user:
     description: The user name of the agent on the instance created from the image_id.
     default: ubuntu
+
+  agents_security_group:
+    description: >
+      The security group to attach to new VM's, to ensure that those VM's can connect
+      to the manager.
+    type: string
+
+  network_name:
+    description: >
+      Openstack network name the new server will be connected to
+
+  floating_network_name:
+    description: >
+      The name of the network to use for allocating a floating ip
+
+  key_pair_name:
+    description: >
+      Openstack key pair name of the key to associate with the new server
+
+  private_key_path:
+    description: |
+      Path to the private key which will be used for connecting to the server
+      on the manager or machine running CLI if running in local mode.
+
+dsl_definitions:
+  openstack_configuration: &openstack_configuration
+    username: { get_input: keystone_username }
+    password: { get_input: keystone_password }
+    tenant_name: { get_input: keystone_tenant_name }
+    auth_url: { get_input: keystone_url }
+    region: { get_input: region }
 
 node_templates:
 
@@ -89,13 +150,40 @@ node_templates:
 
   mongod_host:
     type: nodecellar.nodes.MonitoredServer
+
+    properties:
+      management_network_name: { get_input: network_name }
+      openstack_config: *openstack_configuration
+
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        # Needed to workaround OPENSTACK-38
+        create:
+          inputs:
+            args:
+              security_groups: [{ get_attribute: [agents_security_group, external_name ]}]
+
     relationships:
+
+      ###########################################################
+      # Set the keypair for the VM
+      ###########################################################
+
+      - type: cloudify.openstack.server_connected_to_keypair
+        target: keypair
 
       ###########################################################
       # Attaching the mongo security group to the mongo host
       ###########################################################
 
       - target: mongod_security_group
+        type: cloudify.openstack.server_connected_to_security_group
+
+      ###########################################################
+      # Attaching the agents security group to the mongo host
+      ###########################################################
+
+      - target: agents_security_group
         type: cloudify.openstack.server_connected_to_security_group
 
   nodejs_host:
@@ -106,10 +194,31 @@ node_templates:
     # The default values for instances.deploy is 1.
     ###########################################################
 
-    instances:
-      deploy: 2
+    capabilities:
+      scalable:
+        properties:
+          default_instances: 2
+
+    properties:
+      openstack_config: *openstack_configuration
+      management_network_name: { get_input: network_name }
+
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        # Needed to workaround OPENSTACK-38
+        create:
+          inputs:
+            args:
+              security_groups: [{ get_attribute: [agents_security_group, external_name ]}]
 
     relationships:
+
+      ###########################################################
+      # Set the keypair for the VM
+      ###########################################################
+
+      - type: cloudify.openstack.server_connected_to_keypair
+        target: keypair
 
       ###########################################################
       # Attaching the nodecellar security group to
@@ -119,9 +228,37 @@ node_templates:
       - target: nodecellar_security_group
         type: cloudify.openstack.server_connected_to_security_group
 
+      ###########################################################
+      # Attaching the agents security group to the nodecellar
+      # host
+      ###########################################################
+
+      - target: agents_security_group
+        type: cloudify.openstack.server_connected_to_security_group
+
   haproxy_frontend_host:
     type: nodecellar.nodes.MonitoredServer
+
+    properties:
+      management_network_name: { get_input: network_name }
+      openstack_config: *openstack_configuration
+
+    interfaces:
+      cloudify.interfaces.lifecycle:
+        # Needed to workaround OPENSTACK-38
+        create:
+          inputs:
+            args:
+              security_groups: [{ get_attribute: [agents_security_group, external_name ]}]
+
     relationships:
+
+      ###########################################################
+      # Set the keypair for the VM
+      ###########################################################
+
+      - type: cloudify.openstack.server_connected_to_keypair
+        target: keypair
 
       ###########################################################
       # Attaching an ip to the haproxy frontend host
@@ -138,6 +275,26 @@ node_templates:
       - type: cloudify.openstack.server_connected_to_security_group
         target: haproxy_frontend_security_group
 
+      ###########################################################
+      # Attaching the agents security group to the haxproxy
+      # frontend host
+      ###########################################################
+
+      - target: agents_security_group
+        type: cloudify.openstack.server_connected_to_security_group
+
+  ###########################################################
+  # A security group that we attach to new VM's, to ensure
+  # that the manager and the agents can communicate.
+  ###########################################################
+
+  agents_security_group:
+    type: cloudify.openstack.nodes.SecurityGroup
+    properties:
+      openstack_config: *openstack_configuration
+      use_external_resource: true
+      resource_id: { get_input: agents_security_group }
+
   ###########################################################
   # A security group to enable access to the mongo host
   # using the port of the mongo node.
@@ -150,6 +307,7 @@ node_templates:
   mongod_security_group:
     type: cloudify.openstack.nodes.SecurityGroup
     properties:
+      openstack_config: *openstack_configuration
       security_group:
         name: mongod_security_group
       rules:
@@ -157,6 +315,8 @@ node_templates:
           port: { get_property: [ mongod, port ] }
         - remote_ip_prefix: 0.0.0.0/0
           port: 28017
+        - remote_ip_prefix: 0.0.0.0/0
+          port: 22
 
   ###########################################################
   # A security group to enable access to the nodejs host
@@ -168,11 +328,14 @@ node_templates:
   nodecellar_security_group:
     type: cloudify.openstack.nodes.SecurityGroup
     properties:
+      openstack_config: *openstack_configuration
       security_group:
         name: nodecellar_security_group
       rules:
         - remote_ip_prefix: 0.0.0.0/0
           port: { get_property: [ nodecellar, port ] }
+        - remote_ip_prefix: 0.0.0.0/0
+          port: 22
 
   ###########################################################
   # A security group to enable access to the haproxy frontend
@@ -186,6 +349,7 @@ node_templates:
   haproxy_frontend_security_group:
     type: cloudify.openstack.nodes.SecurityGroup
     properties:
+      openstack_config: *openstack_configuration
       security_group:
         name: haproxy_frontend_security_group
       rules:
@@ -193,6 +357,8 @@ node_templates:
           port: { get_property: [ haproxy, frontend_port ] }
         - remote_ip_prefix: 0.0.0.0/0
           port: { get_property: [ haproxy, statistics_port ]}
+        - remote_ip_prefix: 0.0.0.0/0
+          port: 22
 
   ###########################################################
   # An ip to be attached to the haproxy frontend host, since
@@ -202,6 +368,23 @@ node_templates:
 
   nodecellar_ip:
     type: cloudify.openstack.nodes.FloatingIP
+    properties:
+      openstack_config: *openstack_configuration
+      floatingip:
+        floating_network_name: { get_input: floating_network_name }
+
+  ###########################################################
+  # Key pair for connecting to the VMs using SSH.
+  # The key pair should exist in the OpenStack environment.
+  ###########################################################
+
+  keypair:
+    type: cloudify.openstack.nodes.KeyPair
+    properties:
+      openstack_config: *openstack_configuration
+      use_external_resource: true
+      resource_id: { get_input: key_pair_name }
+      private_key_path: { get_input: private_key_path }
 
 ###########################################################
 # This outputs section exposes the application endpoint.

--- a/types/openstack-types.yaml
+++ b/types/openstack-types.yaml
@@ -9,9 +9,11 @@ node_types:
   nodecellar.nodes.MonitoredServer:
     derived_from: cloudify.openstack.nodes.Server
     properties:
-      cloudify_agent:
+      agent_config:
         default:
           user: { get_input: agent_user }
+          key: { get_input: private_key_path }
+          install_method: remote
       server:
         default:
           image: { get_input: image_id }


### PR DESCRIPTION
Change to avoid relying on provider context.
Fixed syntax for scalability.
Updated for Cloudify 3.4.1 and OpenStack plugin 2.0.